### PR TITLE
ci: auto-approve more dependencies

### DIFF
--- a/.github/workflows/dependabot-auto-approve-minor.yml
+++ b/.github/workflows/dependabot-auto-approve-minor.yml
@@ -12,8 +12,11 @@ jobs:
       matrix:
         dependencyStartsWith:
           - '@sentry/'
+          - '@types/'
           - standard
           - typescript
+          - prettier
+          - debug
     steps:
       - name: Dependabot metadata
         id: metadata


### PR DESCRIPTION
```
- '@types/'
- prettier
- debug
```

See https://github.com/filecoin-station/piece-indexer/pull/100
