### PR TITLE
disable `CODEOWNERS` on pkg files

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,3 @@
-* @bajtos @juliangruber @NikolasHaimerl 
+* @bajtos @juliangruber @NikolasHaimerl
+*/package.json
+package-lock.json


### PR DESCRIPTION
This allows auto merge to happen when github actions approves. https://github.com/orgs/community/discussions/23064

See the currently stuck https://github.com/filecoin-station/piece-indexer/pull/103