### PR TITLE
feat: support for `http-path` multiaddr

### DIFF
--- a/.github/workflows/dependabot-auto-approve-minor.yml
+++ b/.github/workflows/dependabot-auto-approve-minor.yml
@@ -18,6 +18,7 @@ jobs:
           - prettier
           - debug
           - node
+          - multiformats
     steps:
       - name: Dependabot metadata
         id: metadata

--- a/indexer/lib/vendored/multiaddr.js
+++ b/indexer/lib/vendored/multiaddr.js
@@ -6,13 +6,31 @@
  * @returns {string} Parsed URI, e.g. `http://127.0.0.1:80`
  */
 export function multiaddrToHttpUrl (addr) {
-  const [, hostType, hostValue, ipProtocol, port, scheme, ...rest] = addr.split('/')
+  const [multiAddr, httpPathMultiAddr] = addr.split('/http-path')
+  const [, hostType, hostValue, ...multiAddrParts] = multiAddr.split('/')
+  let scheme, path, rest, port
+  if (addr.includes('/http-path')) {
+    [scheme, ...rest] = multiAddrParts
+    try {
+      // Remove leading slash and parse URI-encoded path
+      // See https://github.com/multiformats/multiaddr/blob/cab92e8e6da2e70c5f1b8aa59976e71e6922b392/protocols/http-path.md#usage
+      path = decodeURIComponent(httpPathMultiAddr.substring(1))
+    } catch (err) {
+      throw Object.assign(
+        new Error(`Cannot parse "${addr}": unsupported http path`, { cause: err }),
+        { code: 'INVALID_HTTP_PATH' }
+      )
+    }
+  } else {
+    let ipProtocol
+    ;[ipProtocol, port, scheme, ...rest] = multiAddrParts
 
-  if (ipProtocol !== 'tcp') {
-    throw Object.assign(
-      new Error(`Cannot parse "${addr}": unsupported protocol "${ipProtocol}"`),
-      { code: 'UNSUPPORTED_MULTIADDR_PROTO' }
-    )
+    if (ipProtocol !== 'tcp') {
+      throw Object.assign(
+        new Error(`Cannot parse "${addr}": unsupported protocol "${ipProtocol}"`),
+        { code: 'UNSUPPORTED_MULTIADDR_PROTO' }
+      )
+    }
   }
 
   if (scheme !== 'http' && scheme !== 'https') {
@@ -29,7 +47,10 @@ export function multiaddrToHttpUrl (addr) {
     )
   }
 
-  return `${scheme}://${getUriHost(hostType, hostValue)}${getUriPort(scheme, port)}`
+  let url = `${scheme}://${getUriHost(hostType, hostValue)}`
+  if (port) url += getUriPort(scheme, port)
+  if (path) url += path
+  return url
 }
 
 function getUriHost (hostType, hostValue) {

--- a/indexer/test/advertisement-walker.test.js
+++ b/indexer/test/advertisement-walker.test.js
@@ -57,7 +57,7 @@ describe('processNextAdvertisement', () => {
     })
   })
 
-  it('ignores malformed http-path addresses explains the problem in the status', async () => {
+  it('ignores malformed http-path addresses and explains the problem in the status', async () => {
     /** @type {ProviderInfo} */
     const providerInfo = {
       providerAddress: '/dns/meridian.space/http/http-path/invalid%path',

--- a/indexer/test/advertisement-walker.test.js
+++ b/indexer/test/advertisement-walker.test.js
@@ -19,6 +19,8 @@ import { pipeline } from 'node:stream/promises'
 // TODO(bajtos) We may need to replace this with a mock index provider
 const providerId = '12D3KooWHKeaNCnYByQUMS2n5PAZ1KZ9xKXqsb4bhpxVJ6bBJg5V'
 const providerAddress = 'http://f010479.twinquasar.io:3104'
+const providerAddressHttpPath = '/dns/f03303347-market.duckdns.org/https/http-path/%2Fipni-provider%2F12D3KooWJ91c6xQshrNe7QAXPFAaeRrHWq2UrgXGPf8UmMZMwyZ5'
+
 // The advertisement chain looks this way:
 //
 //  adCid - advertises payloadCid and pieceCid
@@ -35,7 +37,6 @@ const knownAdvertisement = {
   payloadCid: 'bafkreigrnnl64xuevvkhknbhrcqzbdvvmqnchp7ae2a4ulninsjoc5svoq',
   pieceCid: 'baga6ea4seaqlwzed5tgjtyhrugjziutzthx2wrympvsuqhfngwdwqzvosuchmja'
 }
-
 describe('processNextAdvertisement', () => {
   it('ignores non-HTTP(s) addresses and explains the problem in the status', async () => {
     /** @type {ProviderInfo} */
@@ -54,6 +55,26 @@ describe('processNextAdvertisement', () => {
       finished: true,
       newState: {
         status: 'Index provider advertises over an unsupported protocol: /ip4/127.0.0.1/tcp/80'
+      }
+    })
+  })
+
+  it('ignores malformed http-path addresses explains the problem in the status', async () => {
+    /** @type {ProviderInfo} */
+    const providerInfo = {
+      providerAddress: '/dns/meridian.space/http/http-path/invalid%path',
+      lastAdvertisementCID: 'baguqeeraTEST'
+    }
+
+    const result = await processNextAdvertisement({
+      providerId,
+      providerInfo,
+      walkerState: undefined
+    })
+    assert.deepStrictEqual(result, {
+      finished: true,
+      newState: {
+        status: 'Index provider advertises over an unsupported protocol: /dns/meridian.space/http/http-path/invalid%path'
       }
     })
   })

--- a/indexer/test/advertisement-walker.test.js
+++ b/indexer/test/advertisement-walker.test.js
@@ -19,7 +19,6 @@ import { pipeline } from 'node:stream/promises'
 // TODO(bajtos) We may need to replace this with a mock index provider
 const providerId = '12D3KooWHKeaNCnYByQUMS2n5PAZ1KZ9xKXqsb4bhpxVJ6bBJg5V'
 const providerAddress = 'http://f010479.twinquasar.io:3104'
-
 // The advertisement chain looks this way:
 //
 //  adCid - advertises payloadCid and pieceCid

--- a/indexer/test/advertisement-walker.test.js
+++ b/indexer/test/advertisement-walker.test.js
@@ -19,7 +19,6 @@ import { pipeline } from 'node:stream/promises'
 // TODO(bajtos) We may need to replace this with a mock index provider
 const providerId = '12D3KooWHKeaNCnYByQUMS2n5PAZ1KZ9xKXqsb4bhpxVJ6bBJg5V'
 const providerAddress = 'http://f010479.twinquasar.io:3104'
-const providerAddressHttpPath = '/dns/f03303347-market.duckdns.org/https/http-path/%2Fipni-provider%2F12D3KooWJ91c6xQshrNe7QAXPFAaeRrHWq2UrgXGPf8UmMZMwyZ5'
 
 // The advertisement chain looks this way:
 //


### PR DESCRIPTION
**CHANGELOG**

1. Support for `http-path` in `multiaddrToHttpUrl`

The function `multiaddrToHttpUrl` inside of the piece indexer is [copied](https://github.com/CheckerNetwork/piece-indexer/blob/main/indexer/lib/vendored/multiaddr.js#L1) over from the `spark-checker` [repo](https://github.com/CheckerNetwork/spark-checker/blob/main/lib/multiaddr.js#L5).  This function was recently [updated](https://github.com/CheckerNetwork/spark-checker/pull/116) in `spark-checker`. Now we also want to update it here. 
The test added in this PR does not serve as extensive testing but rather a smoke test to show that errors are propagated up the stack as expected, similar to what we are already doing [here](https://github.com/CheckerNetwork/piece-indexer/blob/main/indexer/test/advertisement-walker.test.js#L40). Extensive testing of the function `multiaddrToHttpUrl` is done in the `spark-checker` [repo](https://github.com/CheckerNetwork/spark-checker/blob/main/test/spark.js#L208). 

Related to https://github.com/CheckerNetwork/piece-indexer/issues/117
Loosely related to https://github.com/CheckerNetwork/roadmap/issues/239