### PR TITLE
fix: Move assert-ok-response from dev dependencies

### DIFF
--- a/indexer/package.json
+++ b/indexer/package.json
@@ -8,13 +8,13 @@
     "test": "node --test --test-reporter=spec"
   },
   "devDependencies": {
-    "assert-ok-response": "^1.0.0",
     "standard": "^17.1.2"
   },
   "dependencies": {
     "@filecoin-station/spark-piece-indexer-repository": "^1.0.0",
     "@ipld/dag-cbor": "^9.2.2",
     "@sentry/node": "^9.6.0",
+    "assert-ok-response": "^1.0.0",
     "debug": "^4.4.0",
     "ioredis": "^5.6.0",
     "multiformats": "^13.3.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -39,13 +39,13 @@
         "@filecoin-station/spark-piece-indexer-repository": "^1.0.0",
         "@ipld/dag-cbor": "^9.2.2",
         "@sentry/node": "^9.6.0",
+        "assert-ok-response": "^1.0.0",
         "debug": "^4.4.0",
         "ioredis": "^5.6.0",
         "multiformats": "^13.3.2",
         "p-retry": "^6.2.1"
       },
       "devDependencies": {
-        "assert-ok-response": "^1.0.0",
         "standard": "^17.1.2"
       }
     },
@@ -1347,7 +1347,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/assert-ok-response/-/assert-ok-response-1.0.0.tgz",
       "integrity": "sha512-HdUr5u0Y8RRrODGpwKuvrmxevXT4gJTPApsKHKJlwjfOJv9vdj6jNWGWUwPMI2rsyNWsYiobOGFeaLpkvV18gg==",
-      "dev": true,
       "license": "(Apache-2.0 AND MIT)"
     },
     "node_modules/atomic-sleep": {


### PR DESCRIPTION
Currently `assert-ok-response` is installed as dev dependency which works fine in local environment, but running it in production causes runtime error (raises `ERR_MODULE_NOT_FOUND` error). This PR fixes that my moving `assert-ok-response` from dev dependencies to main dependency list.

